### PR TITLE
Respond with errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,11 +24,14 @@ export default (render: AppCallback, port?: number): void => {
 
   createServer(async (request, response) => {
     const dispatchRoute = routes[<string> request.url] || routes['/404']
+    const server = 'Inertia.js SSR'
 
     try {
-      response.writeHead(200, { 'Content-Type': 'application/json', 'Server': 'Inertia.js SSR' })
+      response.writeHead(200, { 'Content-Type': 'application/json', 'Server': server })
       response.write(JSON.stringify(await dispatchRoute(request)))
     } catch (e) {
+      response.writeHead(500, { 'Content-Type': 'text/html', 'Server': server })
+      response.write(e.stack)
       console.error(e)
     }
 


### PR DESCRIPTION
Respond with a 500 error with the stack in the body of the response on error so it can be logged in the Laravel adapter. This change works with https://github.com/inertiajs/inertia-laravel/pull/425 however neither change relies on the other.